### PR TITLE
add ability to request HEAD

### DIFF
--- a/test/head_request/head.js
+++ b/test/head_request/head.js
@@ -1,0 +1,7 @@
+module.exports = function(tileLayers, tile, done){
+  if ((tileLayers.streets.head.statusCode == 200)) {
+    done(null, tileLayers.streets.head.headers['content-length']);
+  } else {
+    done(null, 0);
+  }
+};

--- a/test/head_request/index.js
+++ b/test/head_request/index.js
@@ -1,0 +1,48 @@
+var test = require('tape');
+var TileReduce = require('../../');
+
+test('head request', function(t){
+  var bbox = [20966,50661,17];
+
+  var opts = {
+    zoom: 17,
+    tileLayers: [
+        {
+          name: 'streets',
+          url: 'https://b.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/{z}/{x}/{y}.vector.pbf?access_token=pk.eyJ1IjoibWF0dCIsImEiOiJTUHZkajU0In0.oB-OGTMFtpkga8vC48HjIg',
+          layers: []
+        }
+      ],
+    map: __dirname + '/head.js',
+    requestMethod: 'HEAD'
+  };
+
+  var filesize = 0;
+  var tilereduce = TileReduce(bbox, opts);
+
+  tilereduce.on('start', function(tiles){
+    t.pass('tilereduce started');
+    t.equal(tiles.length, 1, '1 tile covered');
+    var allValid = tiles.every(function(tile){
+      return tile.length === 3;
+    });
+    t.true(allValid, 'all tiles are valid');
+  });
+
+  tilereduce.on('reduce', function(result){
+    filesize += result;
+  });
+
+  tilereduce.on('end', function(){
+    var minFilesize = 20000;
+    t.true(filesize > minFilesize, 'filesize at least ' + minFilesize + ' (' + filesize + ')');
+    t.pass('tilereduce completed');
+    t.end();
+  });
+
+  tilereduce.on('error', function(error){
+    throw error;
+  });
+
+  tilereduce.run();
+});


### PR DESCRIPTION
Adds the ability to specify the `HEAD` method for requesting just the tiles' header. Useful for checking if a tile exists or its filesize without downloading the actual tile.

Can be specified in the options object passed to tile-reduce with `requestMethod: 'HEAD'`. If this key doesn't exist in the options or is anything other than `HEAD` request will default to `GET` as usual.

Example:
```
{
  zoom: 18,
  tileLayers: [
      {
        name: 'streets',
        url: 'https://b.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/{z}/{x}/{y}.vector.pbf'
      }
    ],
  map: __dirname+'/size-check.js',
  requestMethod: 'HEAD'
}
```

Results are passed in `tileLayers.{name}.head`