### PR TITLE
nextgen-maxrate [not ready]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "eslint src test examples/*/*.js && tap -Rspec test/test.*.js",
-    "cover": "tap test/test.*.js --cov"
+    "cover": "tap test/test.*.js --cov",
+    "lint": "eslint src test examples/*/*.js"
   },
   "repository": {
     "type": "git",
@@ -22,6 +23,7 @@
   "homepage": "https://github.com/mapbox/tile-reduce",
   "dependencies": {
     "binary-split": "^0.1.2",
+    "function-rate-limit": "^1.0.1",
     "mbtiles": "^0.8.2",
     "pbf": "^1.3.5",
     "queue-async": "^1.0.7",

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,6 @@ function tileReduce(options) {
   var workers = [];
   var workersReady = 0;
   var tileStream = null;
-  var tilesDone = 0;
-  var tilesSent = 0;
   var pauseLimit = options.batch || 5000;
   var start = Date.now();
   var handler = new TileHandler(workers, tileStream, pauseLimit, options.maxrate);
@@ -108,11 +106,11 @@ function tileReduce(options) {
 
   function reduce(value) {
     if (value !== null && value !== undefined) ee.emit('reduce', value);
-    if (paused && tilesSent - tilesDone < (pauseLimit / 2)) {
-      paused = false;
-      tileStream.resume();
+    if (handler.paused && handler.tilesSent - handler.tilesDone < (handler.pauseLimit / 2)) {
+      handler.paused = false;
+      handler.tileStream.resume();
     }
-    if (++tilesDone === tilesSent) shutdown();
+    if (++handler.tilesDone === handler.tilesSent) shutdown();
   }
 
   function shutdown() {
@@ -135,7 +133,7 @@ function tileReduce(options) {
     var time = (h ? h + 'h ' : '') + (h || m ? m + 'm ' : '') + (s % 60) + 's';
 
     process.stderr.cursorTo(0);
-    process.stderr.write(tilesDone + ' tiles processed in ' + time);
+    process.stderr.write(handler.tilesDone + ' tiles processed in ' + time);
     process.stderr.clearLine(1);
   }
 

--- a/src/remote.js
+++ b/src/remote.js
@@ -23,7 +23,8 @@ function getTile(source, tile, done) {
 
   tileRequest(url, function(err, res, body) {
     if (err) return done(err);
+    else if (res.statusCode === 200) return done(null, parseVT(body, tile, source));
+    else if (res.statusCode === 404) return done(null, parseVT(null, tile, source));
     else if (res.statusCode !== 200) return done(new Error('Server responded with status code ' + res.statusCode));
-    else done(null, parseVT(body, tile, source));
   });
 }

--- a/src/tilehandler.js
+++ b/src/tilehandler.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var rateLimit = require('function-rate-limit');
+
+var TileHandler = function(workers, tileStream, pauseLimit, maxrate) {
+  this.workers = workers;
+  this.tileStream = tileStream;
+  this.pauseLimit = pauseLimit;
+  this.maxrate = maxrate;
+  this.tilesDone = 0;
+  this.tilesSent = 0;
+  this.paused = false;
+
+  this.handleTile = function(tile) {
+    if(workers.length < 1) throw new Error('No workers initialized.');
+    if(!tileStream) throw new Error('No tilestream initialized.');
+    this.workers[this.tilesSent++ % this.workers.length].send(tile);
+    if (!this.paused && this.tilesSent - this.tilesDone > this.pauseLimit) {
+      this.paused = true;
+      this.tileStream.pause();
+    }
+  }
+  if(this.maxrate) this.handleTile = rateLimit(maxrate, 1000, this.handleTile);
+}
+
+module.exports = TileHandler;

--- a/src/tilehandler.js
+++ b/src/tilehandler.js
@@ -12,15 +12,15 @@ var TileHandler = function(workers, tileStream, pauseLimit, maxrate) {
   this.paused = false;
 
   this.handleTile = function(tile) {
-    if(workers.length < 1) throw new Error('No workers initialized.');
-    if(!tileStream) throw new Error('No tilestream initialized.');
+    if (workers.length < 1) throw new Error('No workers initialized.');
+    if (!tileStream) throw new Error('No tilestream initialized.');
     this.workers[this.tilesSent++ % this.workers.length].send(tile);
     if (!this.paused && this.tilesSent - this.tilesDone > this.pauseLimit) {
       this.paused = true;
       this.tileStream.pause();
     }
-  }
-  if(this.maxrate) this.handleTile = rateLimit(maxrate, 1000, this.handleTile);
-}
+  };
+  if (this.maxrate) this.handleTile = rateLimit(maxrate, 1000, this.handleTile);
+};
 
 module.exports = TileHandler;

--- a/src/vt.js
+++ b/src/vt.js
@@ -6,7 +6,9 @@ var Pbf = require('pbf');
 module.exports = parseData;
 
 function parseData(data, tile, source) {
-  var vt = new VectorTile(new Pbf(data));
+  var vt;
+  if (!data) vt = {layers: {}};
+  else vt = new VectorTile(new Pbf(data));
   return source.raw ? vt.layers : toGeoJSON(vt, tile, source);
 }
 

--- a/test/fixtures/pass.js
+++ b/test/fixtures/pass.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(data, tile, writeData, done) {
+  done(null, null);
+};

--- a/test/test.throttle.js
+++ b/test/test.throttle.js
@@ -30,8 +30,8 @@ test('throttle 10 ops/sec', function(t) {
   })
   .on('end', function() {
     Object.keys(intervals).forEach(function(interval) {
-      if (intervals[interval] > limit*5)
-        t.fail(intervals[interval] + ' ops/sec detected; should be ' + limit + ' ops/sec');
+      if (intervals[interval] > maxrate)
+        t.fail(intervals[interval] + ' ops/sec detected; should be ' + maxrate + ' ops/sec');
       else t.pass(intervals[interval] + ' ops/sec detected');
     });
     t.end();

--- a/test/test.throttle.js
+++ b/test/test.throttle.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var test = require('tap').test;
+var tileReduce = require('../src');
+var path = require('path');
+
+var sources = [
+  {name: 'osm', url: 'https://b.tiles.mapbox.com/v4/morganherlocker.3vsvfjjw/{z}/{x}/{y}.vector.pbf?access_token=pk.eyJ1IjoibW9yZ2FuaGVybG9ja2VyIiwiYSI6Ii1zLU4xOWMifQ.FubD68OEerk74AYCLduMZQ', raw: true},
+  {name: 'tiger', url: 'https://b.tiles.mapbox.com/v4/morganherlocker.4c81vjdd/{z}/{x}/{y}.vector.pbf?access_token=pk.eyJ1IjoibW9yZ2FuaGVybG9ja2VyIiwiYSI6Ii1zLU4xOWMifQ.FubD68OEerk74AYCLduMZQ', raw: true}
+];
+
+var mapPath = path.join(__dirname, 'fixtures/pass.js');
+
+test('throttle 10 ops/sec', function(t) {
+  var intervals = {};
+  var maxrate = 10;
+  tileReduce({
+    bbox: [-122.05862045288086, 36.93768132842635, -121.97296142578124, 37.00378647456494],
+    zoom: 15,
+    map: mapPath,
+    sources: sources,
+    log: false,
+    maxrate: maxrate
+  })
+  .on('reduce', function() {
+    var now = new Date();
+    var time = now.getMinutes() + ':' + now.getSeconds();
+    if (!intervals[time]) intervals[time] = 1;
+    else intervals[time]++;
+  })
+  .on('end', function() {
+    Object.keys(intervals).forEach(function(interval) {
+      if (intervals[interval] > limit*5)
+        t.fail(intervals[interval] + ' ops/sec detected; should be ' + limit + ' ops/sec');
+      else t.pass(intervals[interval] + ' ops/sec detected');
+    });
+    t.end();
+  });
+});

--- a/test/test.tilehandler.js
+++ b/test/test.tilehandler.js
@@ -11,7 +11,7 @@ test('TileHandler', function(t) {
   var workers = [
     {
       send: function(tile) {
-        tilesSent++;
+        if (tile.length === 3) tilesSent++;
       }
     }
   ];

--- a/test/test.tilehandler.js
+++ b/test/test.tilehandler.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var test = require('tap').test;
+var TileHandler = require('../src/tilehandler');
+var streamArray = require('stream-array');
+
+test('TileHandler', function(t) {
+  var maxrate = null;
+  var pauseLimit = 1000;
+  var tilesSent = 0;
+  var workers = [
+    {
+      send: function(tile) {
+        tilesSent++;
+      }
+    }
+  ];
+  var tiles = [
+    [0, 0, 2],
+    [0, 1, 2]
+  ];
+  var tileStream = null;
+  var handler = new TileHandler(workers, tileStream, pauseLimit, maxrate);
+
+  tileStream = streamArray(tiles).on('data', handler.handleTile);
+  t.equal(typeof handler.handleTile, 'function', 'TileHandler instantiated');
+  t.end();
+});


### PR DESCRIPTION
*Moved from #56 cc @morganherlocker*

- add 404 handling for missing tiles (reduce is called but with empty tile data to simulate an empty vector tile). The current behavior is to return an error on 404.
- I started refactoring how tiles are passed to workers to allow for rate limiting, but I'm still figuring out some scoping issues (tileStream yanks the scope from TileHandler, which obscures the state).

cc @mourner @tcql 