### PR TITLE
Enables non-Node map scripts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,10 +41,10 @@ function tileReduce(options) {
   if (output) output.setMaxListeners(0);
 
   for (var i = 0; i < maxWorkers; i++) {
-    var workerArgs = [options.map, JSON.stringify(options.sources)]
+    var workerArgs = [options.map, JSON.stringify(options.sources)];
     var worker;
     if (options.workerCommand) worker = child_process.spawn(options.workerCommand, workerArgs, {
-        stdio:['pipe', 'pipe', 'pipe', 'ipc']
+      stdio: ['pipe', 'pipe', 'pipe', 'ipc']
     });
     else worker = child_process.fork(path.join(__dirname, 'worker.js'), workerArgs, {silent: true});
     worker.stdout.pipe(binarysplit('\x1e')).pipe(output);

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ module.exports = tileReduce;
 
 var EventEmitter = require('events').EventEmitter;
 var cpus = require('os').cpus().length;
-var fork = require('child_process').fork;
+var child_process = require('child_process');
 var path = require('path');
 var binarysplit = require('binary-split');
 var cover = require('./cover');
@@ -41,7 +41,10 @@ function tileReduce(options) {
   if (output) output.setMaxListeners(0);
 
   for (var i = 0; i < maxWorkers; i++) {
-    var worker = fork(path.join(__dirname, 'worker.js'), [options.map, JSON.stringify(options.sources)], {silent: true});
+    //var worker = child_process.fork(path.join(__dirname, 'worker.js'), [options.map, JSON.stringify(options.sources)], {silent: true});
+    var worker = child_process.spawn('python', [options.map, JSON.stringify(options.sources)], {
+      stdio:['pipe', 'pipe', 'pipe', 'ipc']
+    });
     worker.stdout.pipe(binarysplit('\x1e')).pipe(output);
     worker.stderr.pipe(process.stderr);
     worker.on('message', handleMessage);

--- a/src/index.js
+++ b/src/index.js
@@ -41,10 +41,12 @@ function tileReduce(options) {
   if (output) output.setMaxListeners(0);
 
   for (var i = 0; i < maxWorkers; i++) {
-    //var worker = child_process.fork(path.join(__dirname, 'worker.js'), [options.map, JSON.stringify(options.sources)], {silent: true});
-    var worker = child_process.spawn('python', [options.map, JSON.stringify(options.sources)], {
-      stdio:['pipe', 'pipe', 'pipe', 'ipc']
+    var workerArgs = [options.map, JSON.stringify(options.sources)]
+    var worker;
+    if (options.workerCommand) worker = child_process.spawn(options.workerCommand, workerArgs, {
+        stdio:['pipe', 'pipe', 'pipe', 'ipc']
     });
+    else worker = child_process.fork(path.join(__dirname, 'worker.js'), workerArgs, {silent: true});
     worker.stdout.pipe(binarysplit('\x1e')).pipe(output);
     worker.stderr.pipe(process.stderr);
     worker.on('message', handleMessage);


### PR DESCRIPTION
I've been interested in using tile-reduce but with Python analysis code.

I realized you could use a Python worker script in place of worker.js - appropriately setup to use the same interprocess communication channels, parse the command arguments, etc.

The only required change to tile-reduce is to execute the worker script differently. This PR implements this by adding an optional argument to `tileReduce` called `workerCommand`. When `workerCommand` is set, `child_process.spawn(options.workerCommand, ...)` is used with `stdio` set appropriately. When `workerCommand` is omitted, then `fork()` is called with worker.js as before.

A working Python library can be found here: https://github.com/jwass/tile-reduce-py with the canonical buildings and roads count example here: https://github.com/jwass/tile-reduce-py/tree/master/examples/count

The Python code is a proof-of-concept but it's definitely possible to write Python that integrates well with tile-reduce, without having to port everything. I'm pretty excited about the possibilities here.

Thoughts? I have limited experience with Node/Javascript so I'd appreciate any help with the code or gotchas I may have missed.
