### PR TITLE
allows passing mapOptions to workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ tilereduce({
 })
 ```
 
+#### mapOptions
+
+Passes through arbitrary options to workers. Options are made available to map scripts as `global.mapOptions`
+
+```js
+tilereduce({
+	mapOptions: {
+		bufferSize: 4
+	}
+	// ...
+})
+```
+
+
+
 ---
 ### Specifying Sources
 

--- a/src/index.js
+++ b/src/index.js
@@ -39,9 +39,10 @@ function tileReduce(options) {
   log('Starting up ' + maxWorkers + ' workers... ');
 
   if (output) output.setMaxListeners(0);
+  var mapOptions = options.mapOptions || {};
 
   for (var i = 0; i < maxWorkers; i++) {
-    var worker = fork(path.join(__dirname, 'worker.js'), [options.map, JSON.stringify(options.sources)], {silent: true});
+    var worker = fork(path.join(__dirname, 'worker.js'), [options.map, JSON.stringify(options.sources), JSON.stringify(mapOptions)], {silent: true});
     worker.stdout.pipe(binarysplit('\x1e')).pipe(output);
     worker.stderr.pipe(process.stderr);
     worker.on('message', handleMessage);

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,10 +1,11 @@
 'use strict';
 
 var queue = require('queue-async');
-var map = require(process.argv[2]);
-
 var q = queue();
 var sources = [];
+
+global.mapOptions = JSON.parse(process.argv[4]);
+var map = require(process.argv[2]);
 
 JSON.parse(process.argv[3]).forEach(function(source) {
   q.defer(loadSource, source);

--- a/test/fixtures/mapOptions.js
+++ b/test/fixtures/mapOptions.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(data, tile, writeData, done) {
+  done(null, global.mapOptions);
+};

--- a/test/test.workers.js
+++ b/test/test.workers.js
@@ -12,7 +12,6 @@ var sources = [
 
 var mapPath = path.join(__dirname, 'fixtures/count.js');
 
-
 test('workers - 1 per cpu default', function(t) {
   tileReduce({
     zoom: 15,
@@ -47,7 +46,6 @@ test('workers - maxWorker limit is enforced', function(t) {
 });
 
 test('workers - maxWorker limit can\'t exceed CPUs', function(t) {
-
   tileReduce({
     zoom: 15,
     map: mapPath,
@@ -60,6 +58,33 @@ test('workers - maxWorker limit can\'t exceed CPUs', function(t) {
     t.equal(this.workers.length, maxCpus, 'Workers can\'t exceed CPUs');
   })
   .on('end', function() {
+    t.end();
+  });
+});
+
+test('workers - have access to mapOptions', function(t) {
+  var mapOpts = {
+    option1: true,
+    option2: 5
+  };
+  var reduceCount = 0;
+
+  tileReduce({
+    zoom: 15,
+    tiles: [
+      [5282, 12755, 15]
+    ],
+    sources: sources,
+    mapOptions: mapOpts,
+    map: path.join(__dirname, 'fixtures/mapOptions.js'),
+    log: false
+  })
+  .on('reduce', function(result) {
+    reduceCount++;
+    t.deepEqual(mapOpts, result, 'Worker mapOptions are the same as input options');
+  })
+  .on('end', function() {
+    t.equal(reduceCount, 1, 'One tile reduced');
     t.end();
   });
 });


### PR DESCRIPTION
Per #48. Originally I had thought to just serialize the entire options object - but that would be problematic if users were passing in tileStreams or other object instances

cc @mourner @anandthakker