### PR TITLE
Provide drain feedback with callback

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -53,7 +53,6 @@ process.on('message', function(tile) {
   }
 });
 
-function write(data) {
-  process.stdout.write((typeof data === 'string') ? data : JSON.stringify(data));
-  process.stdout.write('\x1e');
+function write(data, cb) {
+  process.stdout.write((typeof data === 'string') ? data : JSON.stringify(data) + '\x1e', cb);
 }


### PR DESCRIPTION
Currently writing to the write stream does not give worker any indication about back pressure not does it handle back pressure itself.

https://github.com/mapbox/tile-reduce/blob/master/src/worker.js#L57-L58

This means that worker will continue to write to the stream even though the data will not make it through to `output`. This can result in only a small fraction of total results being written.

cc/ @mourner @tcql 