### PR TITLE
implement mapOptions parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ tilereduce({
 	// ...
 })
 ```
+
+A map script should export a function that implements the following interface:
+
+```js
+module.exports = function(data, tile, mapOptions, writeData, done) {
+  // call done when the script is done
+  // the first parameter should be any errors
+  // the second parameter should be a value to be reduced by the main thread
+  done(null, null);
+};
+```
+
 #### maxWorkers
 
 By default, TileReduce creates one worker process per CPU. `maxWorkers` may be used to limit the number of workers created

--- a/examples/count/count.js
+++ b/examples/count/count.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(data, tile, writeData, done) {
+module.exports = function(data, tile, mapOptions, writeData, done) {
   var count = 0;
   if (data.osm.roads) count += data.osm.roads.length;
   if (data.osm.buildings) count += data.osm.buildings.length;

--- a/src/worker.js
+++ b/src/worker.js
@@ -4,7 +4,7 @@ var queue = require('queue-async');
 var q = queue();
 var sources = [];
 
-global.mapOptions = JSON.parse(process.argv[4]);
+var mapOptions = JSON.parse(process.argv[4]);
 var map = require(process.argv[2]);
 
 JSON.parse(process.argv[3]).forEach(function(source) {
@@ -49,7 +49,7 @@ process.on('message', function(tile) {
       process.send({reduce: true, value: value, tile: tile});
     }
 
-    map(data, tile, write, gotResults);
+    map(data, tile, mapOptions, write, gotResults);
   }
 });
 

--- a/test/fixtures/count.js
+++ b/test/fixtures/count.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(data, tile, writeData, done) {
+module.exports = function(data, tile, mapOptions, writeData, done) {
   var count = 0;
   if (data.osm.roads) count += data.osm.roads.length;
   if (data.osm.buildings) count += data.osm.buildings.length;

--- a/test/fixtures/mapOptions.js
+++ b/test/fixtures/mapOptions.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = function(data, tile, writeData, done) {
-  done(null, global.mapOptions);
+module.exports = function(data, tile, mapOptions, writeData, done) {
+  done(null, mapOptions);
 };

--- a/test/fixtures/pass.js
+++ b/test/fixtures/pass.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = function(data, tile, writeData, done) {
+module.exports = function(data, tile, mapOptions, writeData, done) {
   done(null, 1);
 };

--- a/test/fixtures/write.js
+++ b/test/fixtures/write.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(data, tile, writeData, done) {
+module.exports = function(data, tile, mapOptions, writeData, done) {
   writeData('{"foo": [100, 200, 300], "hello": "world"},');
   done(null, 1);
 };


### PR DESCRIPTION
This PR [changes mapOptions](https://github.com/mapbox/tile-reduce/issues/80) from a global value that is shimmed into worker processes to a normal function parameter on the map script. It is a breaking change and will require a major version bump, but upgrades should only be a line or two of code.