### PR TITLE
support async

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -67,5 +67,5 @@ process.on('message', function(tile) {
 });
 
 function write(data, cb) {
-  process.stdout.write((typeof data === 'string') ? data : JSON.stringify(data) + '\x1e', cb);
+  process.stdout.write(((typeof data === 'string') ? data : JSON.stringify(data)) + '\x1e', cb);
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -53,12 +53,7 @@ function processTile(tile, callback) {
     var writeQueue = queue(1);
 
     function write(data) {
-      var dataStr = data;
-      if (typeof data !== 'string') dataStr = JSON.stringify(data);
-      dataStr += '\x1e';
-
-      writeQueue.defer(process.stdout.write.bind(process.stdout), dataStr);
-      //process.stdout.write(((typeof data === 'string') ? data : JSON.stringify(data)) + '\x1e', cb);
+      writeQueue.defer(writeStdout, (typeof data !== 'string' ? JSON.stringify(data) : data) + '\x1e');
     }
 
     function gotResults(err, value) {
@@ -71,6 +66,10 @@ function processTile(tile, callback) {
 
     map(data, tile, write, gotResults);
   }
+}
+
+function writeStdout(str, cb) {
+  process.stdout.write(str, cb);
 }
 
 process.on('message', function(tile) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -53,7 +53,6 @@ process.on('message', function(tile) {
   }
 });
 
-function write(data) {
-  process.stdout.write((typeof data === 'string') ? data : JSON.stringify(data));
-  process.stdout.write('\x1e');
+function write(data, cb) {
+  process.stdout.write((typeof data === 'string') ? data : JSON.stringify(data) + '\x1e', cb);
 }

--- a/test/fixtures/write.js
+++ b/test/fixtures/write.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = function(data, tile, writeData, done) {
-  writeData('{"foo": [100, 200, 300], "hello": "world"},', function() {
-    done(null, 1);
-  });
+  writeData('{"foo": [100, 200, 300], "hello": "world"},');
+  done(null, 1);
 };

--- a/test/fixtures/write.js
+++ b/test/fixtures/write.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = function(data, tile, writeData, done) {
-  writeData('{"foo": [100, 200, 300], "hello": "world"},');
-  done(null, 1);
+  writeData('{"foo": [100, 200, 300], "hello": "world"},', function() {
+    done(null, 1);
+  });
 };


### PR DESCRIPTION
Different take on #82 – see there for the motivation behind these changes.

Requires / includes #78.

~~Partially reverts 086dd3e291b46ea7092769ea557ce76a4e4a1b86 because it's otherwise very slow (when running through the `binarysplit` filter, which is unnecessary as far as I can see. //cc @tcql).~~