### PR TITLE
Remove a typo breaking a test

### DIFF
--- a/examples/count/index.js
+++ b/examples/count/index.js
@@ -4,7 +4,7 @@ var tileReduce = require('../../src');
 var path = require('path');
 
 var numFeatures = 0;
-m
+
 tileReduce({
   bbox: [-122.05862045288086, 36.93768132842635, -121.97296142578124, 37.00378647456494],
   zoom: 12,


### PR DESCRIPTION
This reverts commit 117c44303d0b2a257b55cf4d23ba552524028068.

Tests were failing due to an unexpected identifier added to one of the example files.

```bash
> tile-reduce@3.1.1 test /Users/rodowi/Mapbox/tile-reduce
> eslint src test examples/*/*.js && tap -R spec test/test.*.js


/Users/rodowi/Mapbox/tile-reduce/examples/count/index.js
  7:1  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  7:1  error  'm' is not defined                                                     no-undef
  7:2  error  Missing semicolon                                                      semi

✖ 3 problems (3 errors, 0 warnings)
```