### PR TITLE
Add Typescript 2.0 definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "test": "test"
   },
   "scripts": {
-    "test": "eslint src test examples/*/*.js && tap -R spec test/test.*.js",
+    "test": "npm run lint && tap -R spec test/test.*.js && npm run test:types",
     "cover": "tap test/test.*.js --cov --coverage-report=lcov",
+    "test:types": "tsc -p types",
     "lint": "eslint src test examples/*/*.js"
   },
   "repository": {
@@ -39,8 +40,10 @@
     "eslint": "^2.4.0",
     "eslint-config-mourner": "^2.0.0",
     "split": "^1.0.0",
-    "tap": "^5.7.0"
+    "tap": "^5.7.0",
+    "typescript": "^2.0.7"
   },
+  "types": "types/index.d.ts",
   "eslintConfig": {
     "extends": "mourner",
     "rules": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,134 @@
+declare namespace NodeJS  {
+  interface Global {
+    mapOptions: any
+  }
+}
+
+interface startEvent {
+    (): void;
+}
+
+interface mapEvent {
+    (tile: TileReduce.Tile, workerId: number): void;
+}
+
+interface reduceEvent {
+    (result: any, tile: TileReduce.Tile): void;
+}
+
+interface endEvent {
+    (error: any): void;
+}
+
+interface Events {
+    /**
+     * Start Event
+     *
+     * @returns {Events}
+     * @example
+     * tilereduce({...})
+     * .on('start', () => {
+     *     console.log('starting')
+     * })
+     */
+    on(type: 'start', callback: startEvent): Events;
+
+    /**
+     * Map Event
+     *
+     * @param {Tile} tile
+     * @param {number} workerId
+     * @returns {Events}
+     * @example
+     * tilereduce({...})
+     * .on('map', (tile, workerId) => {
+     *     console.log(`about to process [${ tile }] on worker ${ workerId }`)
+     * })
+     */
+    on(type: 'map', callback: mapEvent): Events;
+
+    /**
+     * Reduce Event
+     *
+     * @param {any} result
+     * @param {Tile} tile
+     * @returns {Events}
+     * @example
+     * const count = 0
+     * tilereduce({...})
+     * .on('reduce', (result, tile) => {
+     *     console.log(`got a count of ${ result } from ${ tile }`
+     *     count ++
+     * })
+     */
+    on(type: 'reduce', callback: reduceEvent): Events;
+
+    /**
+     * End Event
+     *
+     * @returns {Events}
+     * @example
+     * let count = 0
+     * tilereduce({...})
+     * .on('end', () => {
+     *     console.log(`Total count was: ${ count }`)
+     * })
+     */
+    on(type: 'end', callback: endEvent): Events;
+}
+
+
+interface Options {
+    map: string;
+    zoom: number;
+    sources: Array<TileReduce.Source>;
+    bbox?: TileReduce.BBox;
+    geojson?: any;
+    log?: boolean;
+    mapOptions?: any;
+    maxWorkers?: number;
+    output?: any;
+    tiles?: Array<TileReduce.Tile>;
+    tileStream?: any;
+    sourceCover?: string;
+}
+
+/**
+ * Tile Reduce
+ *
+ * @param {Options} options Tile Reduce Options
+ * @param {string} options.map Path to the map script, which will be executed against each tile
+ * @param {number} options.zoom Zoom specifies the zoom level of tiles to retrieve from each source.
+ * @param {Array<Source>} options.source Sources are specified as an array
+ * @param {BBox} [options.bbox] BBox extent in [minX, minY, maxX, maxY] order
+ * @param {GeoJSON} [options.geojson] GeoJSON Feature or Feature Collection
+ * @param {boolean} [options.log] Disables logging and progress output
+ * @param {any} [options.mapOptions] Passes through arbitrary options to workers. Options are made available to map scripts as global.mapOptions
+ * @param {number} [options.maxWorkers] By default, TileReduce creates one worker process per CPU. maxWorkers may be used to limit the number of workers created
+ * @param {any} [options.output] By default, any data written from workers is piped to process.stdout on the main process. You can pipe to an alternative writable stream using the output option.
+ * @param {Array<Tile>} [options.tiles] An array of quadtiles represented as xyz arrays.
+ * @param {any} [options.tileStream] Tiles can be read from an object mode node stream. Each object in the stream should be either a string in the format x y z or an array in the format [x, y, z].
+ * @param {string} [options.sourceCover] When using MBTiles sources, a list of tiles to process can be automatically retrieved from the source metadata
+ * @return {Events} TileReduce returns an EventEmitter.
+ * @example
+ * tilereduce({...})
+ * .on('start', () => {
+ *     console.log('starting')
+ * })
+ */
+declare function TileReduce (options: Options): Events;
+
+declare namespace TileReduce {
+    type BBox = [number, number, number, number];
+    type Tile = [number, number, number];
+    interface Source {
+        name: string;
+        mbtiles?: string;
+        url?: string;
+        layers?: Array<string>;
+        maxrate?: number;
+        raw?: boolean;
+    }
+}
+
+export = TileReduce;

--- a/types/test.types.ts
+++ b/types/test.types.ts
@@ -1,0 +1,27 @@
+import * as tilereduce from './index'
+import { BBox, Tile, Source } from './index'
+
+const bbox: BBox = [-120, 40, -110, 50]
+const tile: Tile = [1, 1, 1]
+const source: Source = {
+    name: 'streets',
+    url: 'https://b.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/{z}/{x}/{y}.vector.pbf',
+    layers: ['roads'],
+    maxrate: 10
+}
+
+tilereduce({
+    log: false,
+    maxWorkers: 3,
+    zoom: 15,
+    bbox: bbox,
+    geojson: {"type": "Polygon", "coordinates": [/* coordinates */]},
+    mapOptions: { bufferSize: 4 },
+    sources: [source],
+    map: 'map.js',
+    tiles: [tile],
+})
+.on('start', () => { })
+.on('map', (tile, workerId) => { })
+.on('reduce', (result, tile) => { })
+.on('end', () => { })

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noEmit": true
+  },
+  "files": [
+    "./index.d.ts",
+    "./test.types.ts"
+  ],
+  "compileOnSave": false
+}

--- a/types/typings.json
+++ b/types/typings.json
@@ -1,0 +1,4 @@
+{
+  "name": "tile-reduce",
+  "main": "index.d.ts"
+}


### PR DESCRIPTION
Added Typescript 2.0 definition to be installed automatically from `npm install tile-reduce`.

Used the same types structure as `Vue.js`

https://github.com/vuejs/vue

Alternatively you will also be able to install the defintion via DT via `npm install @types/tile-reduce` whenever this PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12475 gets merged.

Cheers!