### PR TITLE
give map jobs a possibility to properly shut themselves down

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ function tileReduce(options) {
   }
 
   function shutdown() {
-    while (workers.length) workers.pop().kill();
+    while (workers.length) workers.pop().kill('SIGHUP');
 
     clearTimeout(timer);
     updateStatus();


### PR DESCRIPTION
Killing child processes via `SIGHUP` (instead of `SIGTERM`) gives map job processes enough time to do eventually needed (async) shutdown cleanup in a `process.on('SIGHUP', …)` event handler (while the `SIGTERM` induced process termination cannot be canceled AFAIK). This is required for example when the map jobs write output to a file or database (which has to be flushed before closing).